### PR TITLE
Remove final keyword from RedisCache

### DIFF
--- a/src/RedisCache.php
+++ b/src/RedisCache.php
@@ -54,8 +54,9 @@ class RedisCache implements CacheInterface
     public function get($key, $default = null)//@codingStandardsIgnoreLine Interface does not define type-hints or return
     {
         $this->validateKey($key);
-        if ($this->client->exists($key)) {
-            return $this->serializer->unserialize($this->client->get($key));
+
+        if ($cacheItem = $this->client->get($key)) {
+            return $this->serializer->unserialize($cacheItem);
         }
 
         return $default;

--- a/src/RedisCache.php
+++ b/src/RedisCache.php
@@ -10,7 +10,7 @@ use Psr\SimpleCache\CacheInterface;
 /**
  * A PSR-16 implementation which stores data in a RedisDB collection.
  */
-final class RedisCache implements CacheInterface
+class RedisCache implements CacheInterface
 {
     use KeyValidatorTrait;
     use TTLValidatorTrait;


### PR DESCRIPTION
Fixes #6 

#### What does this PR do?
Well, first of all hi again, im still using your library and needed few bugfixes, and i encouter a final keyword. I dont think there should be `final` keywords in libraries at all. Especially in classes which should be used outside your library ( not internal ones ).
