### PR TITLE
Remove use of redis exists in get()

### DIFF
--- a/src/RedisCache.php
+++ b/src/RedisCache.php
@@ -54,8 +54,10 @@ final class RedisCache implements CacheInterface
     public function get($key, $default = null)//@codingStandardsIgnoreLine Interface does not define type-hints or return
     {
         $this->validateKey($key);
-        if ($this->client->exists($key)) {
-            return $this->serializer->unserialize($this->client->get($key));
+
+        $cached = $this->client->get($key);
+        if ($cached !== null) {
+            return $this->serializer->unserialize($cached);
         }
 
         return $default;


### PR DESCRIPTION
Fixes #6 .

#### What does this PR do?
This pull request removes the use of `exists` from the `RedisCache::get` method
#### Checklist
- [ ] Pull request contains a clear definition of changes
- [ ] Tests (either unit, integration, or acceptance) written and passing
- [ ] Relevant documentation produced and/or updated
